### PR TITLE
Pass context to permission interface

### DIFF
--- a/perm.go
+++ b/perm.go
@@ -8,13 +8,13 @@ import "os"
 
 // Perm represents a perm interface
 type Perm interface {
-	GetOwner(string) (string, error)
-	GetGroup(string) (string, error)
-	GetMode(string) (os.FileMode, error)
+	GetOwner(*Context, string) (string, error)
+	GetGroup(*Context, string) (string, error)
+	GetMode(*Context, string) (os.FileMode, error)
 
-	ChOwner(string, string) error
-	ChGroup(string, string) error
-	ChMode(string, os.FileMode) error
+	ChOwner(*Context, string, string) error
+	ChGroup(*Context, string, string) error
+	ChMode(*Context, string, os.FileMode) error
 }
 
 // SimplePerm implements Perm interface that all files are owned by special owner and group
@@ -31,31 +31,31 @@ func NewSimplePerm(owner, group string) *SimplePerm {
 }
 
 // GetOwner returns the file's owner
-func (s *SimplePerm) GetOwner(string) (string, error) {
+func (s *SimplePerm) GetOwner(ctx *Context, path string) (string, error) {
 	return s.owner, nil
 }
 
 // GetGroup returns the group of the file
-func (s *SimplePerm) GetGroup(string) (string, error) {
+func (s *SimplePerm) GetGroup(ctx *Context, path string) (string, error) {
 	return s.group, nil
 }
 
 // GetMode returns the file's mode
-func (s *SimplePerm) GetMode(string) (os.FileMode, error) {
+func (s *SimplePerm) GetMode(ctx *Context, path string) (os.FileMode, error) {
 	return os.ModePerm, nil
 }
 
 // ChOwner changed the file's owner
-func (s *SimplePerm) ChOwner(string, string) error {
+func (s *SimplePerm) ChOwner(ctx *Context, path string, owner string) error {
 	return nil
 }
 
 // ChGroup changed the file's group
-func (s *SimplePerm) ChGroup(string, string) error {
+func (s *SimplePerm) ChGroup(ctx *Context, path string, group string) error {
 	return nil
 }
 
 // ChMode changed the file's mode
-func (s *SimplePerm) ChMode(string, os.FileMode) error {
+func (s *SimplePerm) ChMode(ctx *Context, path string, mode os.FileMode) error {
 	return nil
 }


### PR DESCRIPTION
This change passes the FTP context to the permission interface so that we can consider the context while making decisions about the permissions.